### PR TITLE
Add runtime navmesh drawing

### DIFF
--- a/Assets/UGF.Navigation.Editor.Tests/TestNavMeshView.cs
+++ b/Assets/UGF.Navigation.Editor.Tests/TestNavMeshView.cs
@@ -1,0 +1,22 @@
+﻿using UGF.Navigation.Runtime;
+using UnityEditor;
+
+namespace UGF.Navigation.Editor.Tests
+{
+    public static class TestNavMeshView
+    {
+        [MenuItem("Tests/NavMeshView Display", false, 2000)]
+        private static void DisplayMenu()
+        {
+            NavMeshView.Display = !NavMeshView.Display;
+
+            Menu.SetChecked("Tests/NavMeshView Display", NavMeshView.Display);
+        }
+
+        [MenuItem("Tests/NavMeshView Display", true, 2000)]
+        private static bool DisplayValidate()
+        {
+            return EditorApplication.isPlaying;
+        }
+    }
+}

--- a/Assets/UGF.Navigation.Editor.Tests/TestNavMeshView.cs.meta
+++ b/Assets/UGF.Navigation.Editor.Tests/TestNavMeshView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ef745b0add6546eeb799f9afef9ff309
+timeCreated: 1635605485

--- a/Packages/UGF.Navigation/Runtime/NavMeshUtility.cs
+++ b/Packages/UGF.Navigation/Runtime/NavMeshUtility.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
 
 namespace UGF.Navigation.Runtime
 {
@@ -25,6 +28,72 @@ namespace UGF.Navigation.Runtime
             extents.z = Mathf.Abs(axisX.z) + Mathf.Abs(axisY.z) + Mathf.Abs(axisZ.z);
 
             return new Bounds { center = center, extents = extents };
+        }
+
+        public static Color GetAreaColor(int index)
+        {
+            if (index == 0)
+            {
+                return new Color(0F, 0.75F, 1F, 0.5F);
+            }
+
+            float r = (Bit(index, 4) + Bit(index, 1) * 2 + 1) * 63F / byte.MaxValue;
+            float g = (Bit(index, 3) + Bit(index, 2) * 2 + 1) * 63F / byte.MaxValue;
+            float b = (Bit(index, 5) + Bit(index, 0) * 2 + 1) * 63F / byte.MaxValue;
+
+            return new Color(r, g, b, 0.5F);
+        }
+
+        public static void DrawNavMesh(NavMeshTriangulation triangulation, Material material)
+        {
+            DrawNavMesh(triangulation.vertices, triangulation.indices, triangulation.areas, material);
+        }
+
+        public static void DrawNavMesh(IReadOnlyList<Vector3> vertices, IReadOnlyList<int> indices, IReadOnlyList<int> areas, Material material)
+        {
+            if (vertices == null) throw new ArgumentNullException(nameof(vertices));
+            if (indices == null) throw new ArgumentNullException(nameof(indices));
+            if (areas == null) throw new ArgumentNullException(nameof(areas));
+            if (material == null) throw new ArgumentNullException(nameof(material));
+
+            GL.PushMatrix();
+            GL.MultMatrix(Matrix4x4.identity);
+            GL.Begin(GL.TRIANGLES);
+
+            material.SetPass(0);
+
+            for (int i = 0; i < indices.Count; i += 3)
+            {
+                GL.Color(GetAreaColor(areas[i / 3]));
+                GL.Vertex(vertices[indices[i]]);
+                GL.Vertex(vertices[indices[i + 1]]);
+                GL.Vertex(vertices[indices[i + 2]]);
+            }
+
+            GL.End();
+            GL.Begin(GL.LINES);
+
+            material.SetPass(0);
+
+            GL.Color(Color.black);
+
+            for (int i = 0; i < indices.Count; i += 3)
+            {
+                GL.Vertex(vertices[indices[i]]);
+                GL.Vertex(vertices[indices[i + 1]]);
+                GL.Vertex(vertices[indices[i + 1]]);
+                GL.Vertex(vertices[indices[i + 2]]);
+                GL.Vertex(vertices[indices[i + 2]]);
+                GL.Vertex(vertices[indices[i]]);
+            }
+
+            GL.End();
+            GL.PopMatrix();
+        }
+
+        private static int Bit(int a, int b)
+        {
+            return (a & 1 << b) >> b;
         }
     }
 }

--- a/Packages/UGF.Navigation/Runtime/NavMeshView.cs
+++ b/Packages/UGF.Navigation/Runtime/NavMeshView.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace UGF.Navigation.Runtime
+{
+    public static class NavMeshView
+    {
+        public static bool Display
+        {
+            get { return m_display; }
+            set
+            {
+                if (m_display != value)
+                {
+                    m_display = value;
+
+                    if (value)
+                    {
+                        if (m_triangulation == null)
+                        {
+                            Update();
+                        }
+
+                        Camera.onPostRender += m_handler;
+                    }
+                    else
+                    {
+                        Camera.onPostRender -= m_handler;
+                    }
+                }
+            }
+        }
+
+        public static NavMeshTriangulation Triangulation { get { return m_triangulation ?? throw new ArgumentException("Value not specified."); } }
+        public static bool HasTriangulation { get { return m_triangulation != null; } }
+
+        private static readonly Material m_material;
+        private static readonly Camera.CameraCallback m_handler;
+        private static bool m_display;
+        private static NavMeshTriangulation? m_triangulation;
+
+        static NavMeshView()
+        {
+            m_material = new Material(Shader.Find("Hidden/Internal-Colored"));
+            m_handler = OnRender;
+        }
+
+        public static void SetTriangulation(NavMeshTriangulation triangulation)
+        {
+            m_triangulation = triangulation;
+        }
+
+        public static void ClearTriangulation()
+        {
+            m_triangulation = null;
+        }
+
+        public static void Update()
+        {
+            m_triangulation = NavMesh.CalculateTriangulation();
+        }
+
+        private static void OnRender(Camera _)
+        {
+            if (m_display && m_triangulation != null)
+            {
+                NavMeshUtility.DrawNavMesh(m_triangulation.Value, m_material);
+            }
+        }
+    }
+}

--- a/Packages/UGF.Navigation/Runtime/NavMeshView.cs
+++ b/Packages/UGF.Navigation/Runtime/NavMeshView.cs
@@ -63,7 +63,7 @@ namespace UGF.Navigation.Runtime
 
         private static void OnRender(Camera _)
         {
-            if (m_display && m_triangulation != null)
+            if (Application.isPlaying && m_display && m_triangulation != null)
             {
                 NavMeshUtility.DrawNavMesh(m_triangulation.Value, m_material);
             }

--- a/Packages/UGF.Navigation/Runtime/NavMeshView.cs.meta
+++ b/Packages/UGF.Navigation/Runtime/NavMeshView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b19406436ac4b6e9d4038515d1d0cee
+timeCreated: 1635605052


### PR DESCRIPTION
- Add `NavMeshUtility.DrawNavMesh()` method to draw _NavMesh_ data using _GL_ commands.
- Add `NavMeshUtility.GetAreaColor()` method to get color for each area by the index.
- Add `NavMeshView` static class to control display of _NavMesh_ data in runtime.