### PR TITLE
Fix NavMeshSourceModifierBoxComponent wrong size setup

### DIFF
--- a/Packages/UGF.Navigation/Runtime/NavMeshSourceModifierBoxComponent.cs
+++ b/Packages/UGF.Navigation/Runtime/NavMeshSourceModifierBoxComponent.cs
@@ -19,7 +19,7 @@ namespace UGF.Navigation.Runtime
                 area = Area,
                 shape = NavMeshBuildSourceShape.ModifierBox,
                 transform = transform.localToWorldMatrix * Matrix4x4.TRS(m_center, Quaternion.identity, Vector3.one),
-                size = m_size,
+                size = Vector3.Scale(m_size, transform.localScale),
                 component = this
             };
         }


### PR DESCRIPTION
- Fix `NavMeshSourceModifierBoxComponent` has incorrect `NavMeshBuildSource` size definition.